### PR TITLE
Minor updates needed in `paper_bergonti_2022_tro_kinematics-control-morphingcovers` (PR#1)

### DIFF
--- a/+mystica/+model/getModelCoverSquareLinks.m
+++ b/+mystica/+model/getModelCoverSquareLinks.m
@@ -4,15 +4,22 @@ function model = getModelCoverSquareLinks(input)
         input.m
         input.restConfiguration {mustBeMember(input.restConfiguration,{'flat','cylinder'})}
         input.linkDimension %[m]
+        input.fixedLinksIndexes = []
+        input.baseIndex         = 1;
+        input.tform_0_bBase     = eye(4); %[m]
     end
-
 
     [umc,meshDesign.unitMeas]=mystica.model.setUM('length','m','mass','kg');
 
     meshDesign.shape = 'square';
-    meshDesign.baseIndex = 1;
-    meshDesign.fixedLinksIndexes = [meshDesign.baseIndex];
-    meshDesign.tform_0_bBase = mystica.rbm.getTformGivenPosRotm(zeros(3,1)*(umc.length),mystica.rbm.getRotmGivenEul('rz',0)); %[m]*(umc.length)
+    meshDesign.baseIndex = input.baseIndex;
+    if isempty(input.fixedLinksIndexes)
+        meshDesign.fixedLinksIndexes = [meshDesign.baseIndex];
+    else
+        meshDesign.fixedLinksIndexes = input.fixedLinksIndexes;
+    end
+    meshDesign.tform_0_bBase = input.tform_0_bBase; %[m]
+    meshDesign.tform_0_bBase(1:3,4) = meshDesign.tform_0_bBase(1:3,4)*(umc.length); %[m]*(umc.length)
     meshDesign.linkDimension = input.linkDimension*(umc.length); %[m]*(umc.length)
 
     switch input.restConfiguration
@@ -20,8 +27,8 @@ function model = getModelCoverSquareLinks(input)
             meshDesign.rzi_pj0_cj0 = 0;
             meshDesign.rzj_pj0_cj0 = 0;
         case 'cylinder'
-            meshDesign.rzi_pj0_cj0 = 2*pi/input.n;
-            meshDesign.rzj_pj0_cj0 = 0;
+            meshDesign.rzi_pj0_cj0 = 0;
+            meshDesign.rzj_pj0_cj0 = 2*pi/input.m;
     end
 
     input.name = [meshDesign.shape,sprintf('_%ix%i',input.n,input.m)];

--- a/+mystica/+model/getModelCoverTriangleLinks.m
+++ b/+mystica/+model/getModelCoverTriangleLinks.m
@@ -4,14 +4,22 @@ function model = getModelCoverTriangleLinks(input)
         input.m
         input.restConfiguration {mustBeMember(input.restConfiguration,{'flat','cylinder'})}
         input.linkDimension %[m]
+        input.fixedLinksIndexes = []
+        input.baseIndex         = 1;
+        input.tform_0_bBase     = mystica.rbm.getTformGivenPosRotm(zeros(3,1),mystica.rbm.getRotmGivenEul('rz',pi/3)); %[m]
     end
 
     [umc,meshDesign.unitMeas]=mystica.model.setUM('length','m','mass','kg');
 
     meshDesign.shape = 'triangle';
-    meshDesign.baseIndex = 1;
-    meshDesign.fixedLinksIndexes = [meshDesign.baseIndex];
-    meshDesign.tform_0_bBase = mystica.rbm.getTformGivenPosRotm(zeros(3,1)*(umc.length),mystica.rbm.getRotmGivenEul('rz',pi/3)); %[m]*(umc.length)
+    meshDesign.baseIndex = input.baseIndex;
+    if isempty(input.fixedLinksIndexes)
+        meshDesign.fixedLinksIndexes = [meshDesign.baseIndex];
+    else
+        meshDesign.fixedLinksIndexes = input.fixedLinksIndexes;
+    end
+    meshDesign.tform_0_bBase = input.tform_0_bBase; %[m]
+    meshDesign.tform_0_bBase(1:3,4) = meshDesign.tform_0_bBase(1:3,4)*(umc.length); %[m]*(umc.length)
     meshDesign.linkDimension = input.linkDimension*(umc.length); %[m]*(umc.length)
 
     input.name = [meshDesign.shape,sprintf('_%ix%i',input.n,input.m)];

--- a/+mystica/+stgs/getDefaultSettingsSimKinAbs.m
+++ b/+mystica/+stgs/getDefaultSettingsSimKinAbs.m
@@ -20,7 +20,7 @@ function stgs = getDefaultSettingsSimKinAbs(model,input)
 
     %% Saving & Logger
 
-    stgs.saving.workspace.run         = 1;
+    stgs.saving.workspace.run         = 0;
     stgs.saving.workspace.name        = ['kinAbs_',model.name,'_',strTime,'.mat'];
     stgs.saving.workspace.clearCasadi = 0;
 
@@ -39,7 +39,7 @@ function stgs = getDefaultSettingsSimKinAbs(model,input)
     stgs.integrator.solverOpts.RelTol = 1e-3;
     stgs.integrator.solverOpts.AbsTol = 1e-6;
 
-    stgs.integrator.dxdtOpts.assumeConstant = 0;
+    stgs.integrator.dxdtOpts.assumeConstant = 1;
     stgs.integrator.dxdtParam.baumgarteIntegralCoefficient = 5e1;
 
     stgs.integrator.statusTracker.workspacePrint.run        = 1;
@@ -120,13 +120,13 @@ function stgs = getDefaultSettingsSimKinAbs(model,input)
     stgs.visualizer.cameraView.mBodySimulation.values        = [-37.5,30];
     stgs.visualizer.cameraView.initialRotation.run           = 0;
     stgs.visualizer.cameraView.initialRotation.durationTotal = 3;
-    stgs.visualizer.cameraView.initialRotation.pause.start   = 1;
-    stgs.visualizer.cameraView.initialRotation.pause.end     = 1;
+    stgs.visualizer.cameraView.initialRotation.pause.start   = 0;
+    stgs.visualizer.cameraView.initialRotation.pause.end     = 0;
     stgs.visualizer.cameraView.initialRotation.values        = [0,0];
     stgs.visualizer.cameraView.finalRotation.run             = 0;
-    stgs.visualizer.cameraView.finalRotation.durationTotal   = 5;
-    stgs.visualizer.cameraView.finalRotation.pause.start     = 1;
-    stgs.visualizer.cameraView.finalRotation.pause.end       = 1;
+    stgs.visualizer.cameraView.finalRotation.durationTotal   = 3;
+    stgs.visualizer.cameraView.finalRotation.pause.start     = 0;
+    stgs.visualizer.cameraView.finalRotation.pause.end       = 0;
     stgs.visualizer.cameraView.finalRotation.values          = [90,0];
 
     stgs.visualizer.background = {};

--- a/+mystica/+stgs/getDefaultSettingsSimKinAbs.m
+++ b/+mystica/+stgs/getDefaultSettingsSimKinAbs.m
@@ -12,10 +12,10 @@ function stgs = getDefaultSettingsSimKinAbs(model,input)
 
     %% Desired shape
 
-    stgs.desiredShape.fun = @(x,y)   -1*( ((x-0.15)*2).^2+((y+0.15)*2).^2);
-    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x,y);
-    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x,y,t)-stgs.desiredShape.fun(0,0,t);
-    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x/stgs.unitMeas.converter.length,y/stgs.unitMeas.converter.length,t)*stgs.unitMeas.converter.length;
+    stgs.desiredShape.fun = @(x,y)   -1*( ((x-0.15)*2).^2+((y+0.15)*2).^2); %[m]
+    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x,y); %[m]
+    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x,y,t)-stgs.desiredShape.fun(0,0,t); %[m]
+    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x/stgs.unitMeas.converter.length,y/stgs.unitMeas.converter.length,t)*stgs.unitMeas.converter.length; %[m]*(umc.length)
     stgs.desiredShape.invertNormals = 1;
 
     %% Saving & Logger

--- a/+mystica/+stgs/getDefaultSettingsSimKinRel.m
+++ b/+mystica/+stgs/getDefaultSettingsSimKinRel.m
@@ -20,7 +20,7 @@ function stgs = getDefaultSettingsSimKinRel(model,input)
 
     %% Saving & Logger
 
-    stgs.saving.workspace.run         = 1;
+    stgs.saving.workspace.run         = 0;
     stgs.saving.workspace.name        = ['kinRel_',model.name,'_',strTime,'.mat'];
     stgs.saving.workspace.clearCasadi = 0;
 
@@ -39,7 +39,7 @@ function stgs = getDefaultSettingsSimKinRel(model,input)
     stgs.integrator.solverOpts.RelTol = 1e-3;
     stgs.integrator.solverOpts.AbsTol = 1e-6;
 
-    stgs.integrator.dxdtOpts.assumeConstant = 0;
+    stgs.integrator.dxdtOpts.assumeConstant = 1;
     stgs.integrator.dxdtParam.baumgarteIntegralCoefficient = 5e1;
     stgs.integrator.dxdtParam.regTermDampPInv = 1e-6;
 
@@ -139,13 +139,13 @@ function stgs = getDefaultSettingsSimKinRel(model,input)
     stgs.visualizer.cameraView.mBodySimulation.values        = [230 40];
     stgs.visualizer.cameraView.initialRotation.run           = 0;
     stgs.visualizer.cameraView.initialRotation.durationTotal = 3;
-    stgs.visualizer.cameraView.initialRotation.pause.start   = 1;
-    stgs.visualizer.cameraView.initialRotation.pause.end     = 1;
+    stgs.visualizer.cameraView.initialRotation.pause.start   = 0;
+    stgs.visualizer.cameraView.initialRotation.pause.end     = 0;
     stgs.visualizer.cameraView.initialRotation.values        = [0,0];
     stgs.visualizer.cameraView.finalRotation.run             = 0;
-    stgs.visualizer.cameraView.finalRotation.durationTotal   = 5;
-    stgs.visualizer.cameraView.finalRotation.pause.start     = 1;
-    stgs.visualizer.cameraView.finalRotation.pause.end       = 1;
+    stgs.visualizer.cameraView.finalRotation.durationTotal   = 3;
+    stgs.visualizer.cameraView.finalRotation.pause.start     = 0;
+    stgs.visualizer.cameraView.finalRotation.pause.end       = 0;
     stgs.visualizer.cameraView.finalRotation.values          = [90,0];
 
     stgs.visualizer.background = {};

--- a/+mystica/+stgs/getDefaultSettingsSimKinRel.m
+++ b/+mystica/+stgs/getDefaultSettingsSimKinRel.m
@@ -28,7 +28,7 @@ function stgs = getDefaultSettingsSimKinRel(model,input)
 
     stgs.stateKin.nullSpace.decompositionMethod    = 'qrFull';
     stgs.stateKin.nullSpace.rankRevealingMethod    = 'limitParFunRatioSingularValues';
-    stgs.stateKin.nullSpace.toleranceRankRevealing = [10 1e-5];
+    stgs.stateKin.nullSpace.toleranceRankRevealing = [10 1e-8];
 
     %% Integration Settings
 

--- a/+mystica/+stgs/getDefaultSettingsSimKinRel.m
+++ b/+mystica/+stgs/getDefaultSettingsSimKinRel.m
@@ -12,10 +12,10 @@ function stgs = getDefaultSettingsSimKinRel(model,input)
 
     %% Desired shape
 
-    stgs.desiredShape.fun = @(x,y)   0.005*(5*cos(10*x-2)+5*cos(10*x-20*y));
-    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x-t/8e1,y-t/8e1);
-    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x,y,t)-stgs.desiredShape.fun(0,0,t);
-    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x/stgs.unitMeas.converter.length,y/stgs.unitMeas.converter.length,t)*stgs.unitMeas.converter.length;
+    stgs.desiredShape.fun = @(x,y)   0.005*(5*cos(10*x-2)+5*cos(10*x-20*y)); %[m]
+    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x-t/8e1,y-t/8e1); %[m]
+    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x,y,t)-stgs.desiredShape.fun(0,0,t); %[m]
+    stgs.desiredShape.fun = @(x,y,t) stgs.desiredShape.fun(x/stgs.unitMeas.converter.length,y/stgs.unitMeas.converter.length,t)*stgs.unitMeas.converter.length; %[m]*(umc.length)
     stgs.desiredShape.invertNormals = 1;
 
     %% Saving & Logger

--- a/+mystica/+utils/createTimeTrackerFile.m
+++ b/+mystica/+utils/createTimeTrackerFile.m
@@ -12,11 +12,14 @@ function nameNew = createTimeTrackerFile(nameOld,baseName,actualValue,maxValue)
     end
     if maxValue == 0
         nameNew = [baseName,'_',num2str(actualValue),'.txt'];
-    else
+        fileID = fopen(nameNew,'w');
+        fclose(fileID);
+    elseif actualValue < maxValue
         nameNew = [baseName,'_',num2str(actualValue),'-',num2str(maxValue),'.txt'];
+        fileID = fopen(nameNew,'w');
+        fclose(fileID);
+    else
+        nameNew = '';
     end
-
-    fileID = fopen(nameNew,'w');
-    fclose(fileID);
 
 end

--- a/+mystica/+viz/@VisualizerMatlab/rotateCameraView.m
+++ b/+mystica/+viz/@VisualizerMatlab/rotateCameraView.m
@@ -6,7 +6,7 @@ function rotateCameraView(obj,durationTotal,durationInitialPhase,durationFinalPh
 
     for indexStepRotation = 1 : nFrames
         tickInstantValue = indexStepRotation/nFrames;
-        deltaAngle  = wrapTo180(finalView - initialView);
+        deltaAngle  = [wrapDegTo180(finalView(1) - initialView(1)) wrapDegTo180(finalView(2) - initialView(2))];
         instantView = initialView + computeCompositeTrajectory(deltaAngle,tickInstantValue,tickInitialPause,tickFinalPause);
         view(instantView);
         if obj.stgsVisualizer.gif.save || obj.stgsVisualizer.video.save
@@ -28,5 +28,17 @@ function  finalPos = computeCompositeTrajectory(angleIncrement,tickInstantValue,
         finalPos = computeSinusoidalTrajectory(angleIncrement,(tickInstantValue-tickInitialPause)/(tickFinalPause-tickInitialPause));
     else
         finalPos = angleIncrement;
+    end
+end
+
+function q = wrapDegTo180(q)
+    if abs(q)>=360
+        q = mod(q,360);
+    end
+    if q > 180
+        q = q - 360;
+    end
+    if q < -180
+        q = 360 + q;
     end
 end

--- a/+mystica/+viz/@VisualizerMatlab/rotateCameraView.m
+++ b/+mystica/+viz/@VisualizerMatlab/rotateCameraView.m
@@ -38,7 +38,7 @@ function q = wrapDegTo180(q)
     if q > 180
         q = q - 360;
     end
-    if q < -180
+    if q <= -180
         q = 360 + q;
     end
 end

--- a/+mystica/+viz/visualizeKinRel.m
+++ b/+mystica/+viz/visualizeKinRel.m
@@ -6,8 +6,7 @@ function visual = visualizeKinRel(input)
     end
     dataLiveStatistics{1} = struct('data',abs(input.data.errorOrientationNormals),'title','Error alignment normal vectors','ylabel','Angle $[deg]$');
     dataLiveStatistics{2} = struct('data',abs(input.data.errorPositionNormals),'title','Node position error','ylabel','Distance $[m]$');
-    dataLiveStatistics{3} = struct('data',abs(input.data.jointsAngVel_PJ),'title','Joint Angular velocity','ylabel','Velocity $[\frac{rad}{s}]$');
-    dataLiveStatistics{4} = struct('data',abs(input.data.nDoF),'title','degrees of freedom','ylabel','DoF $[]$');
+    dataLiveStatistics{3} = struct('data',abs(input.data.motorsAngVel)*180/pi,'title','Motor Angular velocity','ylabel','Velocity $[\frac{deg}{s}]$');
     visual = mystica.viz.VisualizerMatlab('data',input.data,'stgs',input.stgs,'model',input.model,'dataLiveStatistics',dataLiveStatistics);
     visual.runVisualizer()
     visual.save()

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The _maximal_ representation consists of a set of _non-minimum_ variables 𝐪 c
 
 - [:hammer: Dependencies](#hammer-dependencies)
 - [:floppy_disk: Installation](#floppy_disk-installation)
+    - [⚠️ Known issue](#️-known-issue)
 - [:rocket: Usage](#rocket-usage)
 - [:gear: Contributing](#gear-contributing)
 
@@ -60,11 +61,7 @@ The function [`install()`](install.m) downloads [`mambaforge`](https://github.co
 
 
 #### ⚠️ Known issue
-For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi producing this error:
-```matlab
-Invalid MEX-file '.../envs/imorph/mex/casadiMEX.mexa64': /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version 'GLIBCXX_3.4.26' not found
-``` 
-See also https://github.com/robotology/robotology-superbuild/issues/64). A possible workaround is to launch `matlab` with LD_PRELOAD
+For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi (see issue #6). A possible workaround is to launch `matlab` with LD_PRELOAD
 ```
 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6 matlab
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The _maximal_ representation consists of a set of _non-minimum_ variables 𝐪 c
 
 - [:hammer: Dependencies](#hammer-dependencies)
 - [:floppy_disk: Installation](#floppy_disk-installation)
-    - [⚠️ Known issue](#️-known-issue)
 - [:rocket: Usage](#rocket-usage)
 - [:gear: Contributing](#gear-contributing)
 
@@ -60,7 +59,7 @@ The function [`install()`](install.m) downloads [`mambaforge`](https://github.co
 </details>
 
 
-#### ⚠️ Known issue
+⚠️ **Known issue**
 For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi (see [issue](https://github.com/ami-iit/mystica/issues/6)). A possible workaround is to launch `matlab` with LD_PRELOAD
 ```
 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6 matlab

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The function [`install()`](install.m) downloads [`mambaforge`](https://github.co
 
 
 #### ⚠️ Known issue
-For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi (see [issue](https://github.com/ami-iit/mystica/issues/6) #6). A possible workaround is to launch `matlab` with LD_PRELOAD
+For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi (see [issue](https://github.com/ami-iit/mystica/issues/6)). A possible workaround is to launch `matlab` with LD_PRELOAD
 ```
 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6 matlab
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Multi bodY SimulaTor maxImal CoordinAtes**
 
-**mystica** is a library of classes and functions to simulate multibody systems.
+**mystica** is a matlab library to simulate the kinematics of multibody systems.
 **mystica** computes the system evolution modeling the problem using a state definition that we define _maximal_.
 The _maximal_ representation consists of a set of _non-minimum_ variables 𝐪 complemented by holonomic constraint g(𝐪) = 0.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The function [`install()`](install.m) downloads [`mambaforge`](https://github.co
 
 
 #### ⚠️ Known issue
-For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi (see issue #6). A possible workaround is to launch `matlab` with LD_PRELOAD
+For some versions of Ubuntu and Matlab, Matlab is not able to load the required libraries like CasADi (see [issue](https://github.com/ami-iit/mystica/issues/6) #6). A possible workaround is to launch `matlab` with LD_PRELOAD
 ```
 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6 matlab
 ```


### PR DESCRIPTION
- clarify unit of measuraments definying desired shape.
- update [`createTimeTrackerFile.m`](https://github.com/ami-iit/mystica/pull/3/files#diff-5ed98496601d60898c61417d93973dcf88147e93abcea52c16b8828569ad062d) to delete the last autogenerated file.
- update live statistics [`visualizeKinRel.m`](https://github.com/ami-iit/mystica/pull/3/files#diff-78765fe6854a1a564338156211ec801129020b0f2ca9efaf9e6c83ee349d71f8)
- improve model generation. 
It's now possible to select indexes of fixed links, index of the base link, origin and orientation of the base link wrt to the world
- update default stgs

follow https://github.com/ami-iit/paper_bergonti_2022_tro_kinematics-control-morphingcovers/pull/1