### PR TITLE
Implement pseudoinverse inside NullSpace class

### DIFF
--- a/+mystica/+utils/@NullSpace/NullSpace.m
+++ b/+mystica/+utils/@NullSpace/NullSpace.m
@@ -1,8 +1,9 @@
 classdef NullSpace < handle
-    
+
     properties (SetAccess = protected, GetAccess = public)
         A
         Z
+        pinvAred
         rank = []
         singValues
         stgs
@@ -12,7 +13,7 @@ classdef NullSpace < handle
         linIndRow
         V
     end
-    
+
     methods
         function obj = NullSpace(input)
             arguments
@@ -24,12 +25,12 @@ classdef NullSpace < handle
             obj.stgs.decompositionMethod   = input.decompositionMethod;
             obj.stgs.rankRevealingMethod   = input.rankRevealingMethod;
             obj.stgs.toleranceRankRevealing = input.toleranceRankRevealing;
-            
+
             if isempty(input.A) == 0
                 obj.compute(input.A)
             end
         end
-        
+
         function Z = compute(obj,A)
             switch obj.stgs.decompositionMethod
                 case 'qrFull'
@@ -44,7 +45,7 @@ classdef NullSpace < handle
             end
             Z = obj.Z;
         end
-        
+
         function linIndRow = getLinIndRow(obj)
             switch obj.stgs.decompositionMethod
                 case 'svd'
@@ -53,28 +54,39 @@ classdef NullSpace < handle
             end
             linIndRow = obj.linIndRow;
         end
-        
+
     end
-    
+
     methods (Access=protected)
         getRank(obj)
-        
+
         function qr(obj)
-            [Q,R,p] = qr(transpose(obj.A),'vector');
+            [Q,R,P] = qr(transpose(obj.A));
+            [p,~] = find(P); p=p';
             obj.singValues = full(abs(diag(R)));
             obj.V = full(Q);
             obj.getRank();
             obj.Z = obj.V(:,(obj.rank+1):end);
             obj.linIndRow = sort(p(1:obj.rank));
+            %
+            Q1 = Q(:,1:obj.rank);
+            R1 = R(1:obj.rank,1:obj.rank);
+            P1 = P(:,1:obj.rank); P1(sum(P1,2)==0,:)=[];
+            obj.pinvAred = Q1*((R1')\(inv(P1)));
         end
-        
+
         function svd(obj)
-            [~,S,obj.V] = svd(obj.A,0);
+            [U,S,obj.V] = svd(obj.A,0);
             obj.singValues = diag(S);
             obj.getRank();
             obj.Z = obj.V(:,(obj.rank+1):end);
+            %
+            Ur = U(:,1:obj.rank);
+            Sr = S(1:obj.rank,1:obj.rank); invSr = diag(1./diag(Sr));
+            Vr = obj.V(:,1:obj.rank);
+            obj.pinvAred = Vr * invSr * Ur';
         end
-        
+
     end
-    
+
 end

--- a/+mystica/+utils/@NullSpace/NullSpace.m
+++ b/+mystica/+utils/@NullSpace/NullSpace.m
@@ -17,7 +17,7 @@ classdef NullSpace < handle
     methods
         function obj = NullSpace(input)
             arguments
-                input.decompositionMethod    char   = 'svd'
+                input.decompositionMethod    char {mustBeMember(input.decompositionMethod,{'svd','qrFull','qrSparse'})} = 'svd'
                 input.rankRevealingMethod    char   = 'limitSingularValue_tolAuto'
                 input.toleranceRankRevealing double = []
                 input.A                      double = []


### PR DESCRIPTION
This PR implements the computation of the pseudoinverse inside [`NullSpace class`](https://github.com/ami-iit/mystica/blob/0b9e7dce10bc781e923064d36c8a2dc2708b277b/%2Bmystica/%2Butils/%40NullSpace/NullSpace.m#L1).
The pseudoinverse is computed using the same tolerance used for defining rank and nullspace.
The pseudoinverse is computed for:
- the matrix A (relying on `SVD`)
- the matrix A reduced (relying on`QR`)

## `pinv(A)`
Given $A=U \Sigma V^{\top}$

$$
A^{\dagger} = V \Sigma^{-1} U^{\top}
$$

In case $A$ is singular $A=U_r \Sigma_r V_r^{\top}$

$$
A^{\dagger} = V_r \Sigma_r^{-1} U_r^{\top}
$$

## `pinv(Ar)`
Given $A^{\top} = Q R P^{\top}$

In case $A$ is singular with linear dependent rows, we use the reduced matrix $A_r$ that is non-singular and fat (otherwise nullspace is empty) and is equal to $A_r^{\top} = Q_1 R_1 P_1^{\top}$.
$A_r$ is the matrix $A$ without the linear dependent rows.

$$
A_r = P_1 R_1^{\top} Q_1^{\top}
$$

Since $A_r$ is non-singular and fat, we can apply the formula

$$
A_r^{\dagger} = A_r^{\top} (A_r A_r^{\top})^{-1} = A_r^{\top} = Q_1 R_1 P_1^{\top} (P_1 R_1^{\top} Q_1^{\top} Q_1 R_1 P_1^{\top})^{-1}
$$

$Q_1$ is an orthogonal matrix

$$
A_r^{\dagger}  = Q_1 R_1 P_1^{\top} (P_1 R_1^{\top} R_1 P_1^{\top})^{-1}
$$

$R_1$ and $P_1$ are non-singular square matrices

$$
A_r^{\dagger}  = Q_1 R_1 P_1^{\top} P_1^{-\top} R_1^{-1} R_1^{-\top} P_1^{-1}
$$

$$
A_r^{\dagger}  =  Q_1 R_1^{-\top} P_1^{-1}
$$